### PR TITLE
README: Fix URL to font package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ GitHub hochgeladen werden!
 
 Benötigte Schriftarten
 ----------------------
-* [unifont](http://packages.debian.org/squeeze/ttf-unifont)
+* [unifont](https://packages.debian.org/sid/ttf-unifont)


### PR DESCRIPTION
Debian has moved on and will do, just link to the package in
unstable/sid instead of some probably already outdated release.

Reported-by: Benjamin Hatscher <b.hatscher@gmail.com>
Fixes: #19